### PR TITLE
Ndk generate token refactor

### DIFF
--- a/Assets/Inworld/Inworld.NDK/Scripts/InworldNDKBridge.cs
+++ b/Assets/Inworld/Inworld.NDK/Scripts/InworldNDKBridge.cs
@@ -46,7 +46,7 @@ namespace Inworld.NDK
                 (
                     instance,
                     "DefaultClientNDK",
-                    "1.0.0", connectionStateCallback, packetCallback, logCallback, tokenCallback
+                    "1.0.0", connectionStateCallback, packetCallback, logCallback
                 );
             }
         }
@@ -82,10 +82,10 @@ namespace Inworld.NDK
         public static extern void ClientWrapper_StopAudioSession(IntPtr wrapper, string agentId);
 
         [DllImport("InworldNDK", CallingConvention = CallingConvention.Cdecl, EntryPoint = "ClientWrapper_InitClient")]
-        public static extern void ClientWrapper_InitClient(IntPtr wrapper, string clientId, string clientVer, ConnectionStateCallbackType connectionStateCallback, PacketCallbackType packetCallback, LogCallbackType logCallback, TokenCallbackType tokenCallback);
+        public static extern void ClientWrapper_InitClient(IntPtr wrapper, string clientId, string clientVer, ConnectionStateCallbackType connectionStateCallback, PacketCallbackType packetCallback, LogCallbackType logCallback);
 
         [DllImport("InworldNDK", CallingConvention = CallingConvention.Cdecl, EntryPoint = "ClientWrapper_StartClientWithCallback")]
-        public static extern void ClientWrapper_StartClientWithCallback(IntPtr wrapper, byte[] serializedOptions, int serializedOptionsSize, byte[] serializedSessionInfo, int sessionInfoSize, LoadSceneCallbackType loadSceneCallback);
+        public static extern void ClientWrapper_StartClientWithCallback(IntPtr wrapper, byte[] serializedOptions, int serializedOptionsSize, byte[] serializedSessionInfo, int sessionInfoSize, LoadSceneCallbackType loadSceneCallback, TokenCallbackType tokenCallback);
 
         [DllImport("InworldNDK", CallingConvention = CallingConvention.Cdecl, EntryPoint = "ClientWrapper_StartClient")]
         public static extern void ClientWrapper_StartClient(IntPtr wrapper, byte[] serializedOptions, int serializedOptionsSize);

--- a/Assets/Inworld/Inworld.NDK/Scripts/InworldNDKClient.cs
+++ b/Assets/Inworld/Inworld.NDK/Scripts/InworldNDKClient.cs
@@ -46,6 +46,8 @@ namespace Inworld.NDK
 
         void ConnectionStateCallback(ConnectionState state)
         {
+            InworldAI.Log("connection state from ndk is " + state.ToString());
+
             switch (state)
             {
                 case ConnectionState.Connected:
@@ -90,7 +92,7 @@ namespace Inworld.NDK
             m_CustomToken = String.Copy(token);
             Marshal.FreeCoTaskMem(Marshal.StringToHGlobalAnsi(token));
             if(_ReceiveCustomToken())
-                InworldAI.Log("NDK Token received");
+                InworldAI.Log("Valid NDK Token received");
         }
         
         void LogCallback(string message, int severity)
@@ -266,7 +268,7 @@ namespace Inworld.NDK
             InworldNDKBridge.ClientWrapper_StartClientWithCallback
             (
                 m_Wrapper.instance, serializedData,
-                serializedData.Length, serializedSessionInfo, serializedSessionInfo.Length, m_Callback
+                serializedData.Length, serializedSessionInfo, serializedSessionInfo.Length, m_Callback, m_TokenCallbackType
             ); 
         }
 


### PR DESCRIPTION
Refactored Token callback to remove ifdef c++ side. These are corresponding changes to account for said changes in the dll moving token callback from Init to StartClient